### PR TITLE
Fix jaxb2 compile error

### DIFF
--- a/cedar-submission-server-core/pom.xml
+++ b/cedar-submission-server-core/pom.xml
@@ -132,6 +132,13 @@
           <schemaDirectory>${basedir}/src/main/resources/xsd</schemaDirectory>
           <!-- <generatePackage>org.metadatacenter.submission</generatePackage> -->
         </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>2.3.3</version>
+          </dependency>
+        </dependencies>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
It passes the compilation with JDK11, JDK15, JDK17

Source: https://github.com/highsource/maven-jaxb2-plugin/issues/201

